### PR TITLE
postとtagのリレーション対応

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 use App\Models\User;
 use App\Models\Category;
+use App\Models\Tag;
 
 class Post extends Model
 {
@@ -22,5 +23,9 @@ class Post extends Model
 
     public function category(){
         return $this->belongsTo(Category::class);
+    }
+
+    public function tags(){
+        return $this->belongsToMany(Tag::class);
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+use App\Models\Post;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    public function posts(){
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/database/migrations/2024_05_22_232641_create_tags_table.php
+++ b/database/migrations/2024_05_22_232641_create_tags_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('tag_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2024_05_22_234122_create_post_tag_table.php
+++ b/database/migrations/2024_05_22_234122_create_post_tag_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('post_id');
+            $table->foreign('post_id')->references('id')->on('posts');
+            $table->unsignedBigInteger('tag_id');
+            $table->foreign('tag_id')->references('id')->on('tags');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+    }
+};


### PR DESCRIPTION
- postとtagが多対多のため、post_tagテーブルという中間テーブルを作成
- 中間テーブルにpost_idとtag_idを外部キーとして設定